### PR TITLE
Harden build workflow: Node 22, concurrency, timeout, path filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,20 +5,28 @@ name: Build
 on:
   push:
     branches: [ "main" ]
+    paths-ignore: [ "**/*.md", "images/**" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore: [ "**/*.md", "images/**" ]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 22.x
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 22.x
         cache: 'npm'
     - run: npm ci
     - run: npm run build


### PR DESCRIPTION
**CI hardening.** Updates the build workflow to Node 22, adds a `concurrency` group (cancel-in-progress), `timeout-minutes`, and path filters to avoid redundant runs.

---
**Notes**
- Snyk steps need maintainer-side `SNYK_TOKEN`/`SNYK_ORG` secrets; fork-PR CI runs only after a maintainer clicks *Approve and run*.
- DCO: commit signed off by Daniel Casota.